### PR TITLE
Bird audio indentification server proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ MAIL_BASE=beta.laji.fi
 MAIL_API_BASE=apitest.laji.fi
 NO_MAIL=true
 WAREHOUSE_HOST=https://staging.laji.fi/laji-etl
+SOUND_IDENTIFICATION_HOST=
 LAJI_BACKEND_HOST=https://staging.laji.fi/lajitietokeskus/api
 SECONDARY_SYSTEM=KE.981
 SECONDARY_TOKEN=

--- a/integration-test/sound-identification/tests.js
+++ b/integration-test/sound-identification/tests.js
@@ -1,0 +1,40 @@
+var config = require("../config.json");
+require("../helpers");
+const { request } = require("chai");
+
+describe("/sound-identification", function() {
+	var basePath = config.urls["sound-identification"];
+
+	it("POST returns 401 when no access token specified", function(done) {
+		request(this.server)
+			.post(basePath)
+			.end(function(err, res) {
+				res.should.have.status(401);
+				done();
+			});
+	});
+
+
+	it("POST returns 400 when no personToken specified", function(done) {
+    const url = basePath
+      + "?access_token=" + config.access_token;
+		request(this.server)  
+			.post(url)
+			.end(function(err, res) {
+				res.should.have.status(400);
+				done();
+			});
+	});
+
+	it("POST proxy works", function(done) {
+    const url = basePath
+      + "?access_token=" + config.access_token
+      + "&personToken=" + config.user.token;
+		request(this.server)
+			.post(url)
+			.end(function(err, res) {
+				res.should.have.status(422);
+				done();
+			});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:e2e-old": "mocha --timeout 6000 --require integration-test/setup.js ./integration-test/{form-permission,forms,collection,person,notifications,api-user,audio,image,warehouse,named-place,trait,document,annotation,area,information}/tests.js ./integration-test/document/validate-tests.js ./integration-test/document/batch-tests.js --exit",
+    "test:e2e-old": "mocha --timeout 6000 --require integration-test/setup.js ./integration-test/{sound-identification,form-permission,forms,collection,person,notifications,api-user,audio,image,warehouse,named-place,trait,document,annotation,area,information}/tests.js ./integration-test/document/validate-tests.js ./integration-test/document/batch-tests.js --exit",
     "test:e2e-old:ci": "npm run test:e2e-old -- -R xunit --grep @no-ci --invert",
     "docker": "docker-compose -f docker-compose.npm-run.yml run npm-run"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -51,6 +51,7 @@ import { ErrorLoggerFilter } from "./filters/error-logger.filter";
 import { GlobalRestClientModule } from "./rest-client/global-rest-client.module";
 import { InstanceToPlainInterceptor } from "./interceptors/instance-to-plain.interceptor";
 import { JsonLdModule } from "./json-ld/json-ld.module";
+import { SoundIdentificationModule } from "./sound-identification/sound-identifiation.module";
 
 @Module({
 	imports: [
@@ -106,7 +107,8 @@ import { JsonLdModule } from "./json-ld/json-ld.module";
 		LoggerModule,
 		InformalTaxonGroupsModule,
 		GlobalRestClientModule,
-		JsonLdModule
+		JsonLdModule,
+		SoundIdentificationModule
 	],
 	controllers: [AppController],
 	providers: [

--- a/src/sound-identification/sound-identifiation.module.ts
+++ b/src/sound-identification/sound-identifiation.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { SoundIdentificationController } from "./sound-identification.controller";
+
+@Module({
+	providers: [],
+	controllers: [SoundIdentificationController],
+	exports: []
+})
+export class SoundIdentificationModule {}

--- a/src/sound-identification/sound-identification.controller.ts
+++ b/src/sound-identification/sound-identification.controller.ts
@@ -1,0 +1,45 @@
+import { createProxyMiddleware } from "http-proxy-middleware";
+import { Controller, HttpException, Logger, Next, Post, Req, Res } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { NextFunction, Request, Response } from "express";
+import { ApiUser } from "src/decorators/api-user.decorator";
+import { ApiUserEntity } from "src/api-users/api-user.entity";
+import { PersonToken } from "src/decorators/person-token.decorator";
+import { Person } from "src/persons/person.dto";
+
+@Controller("sound-identification")
+export class SoundIdentificationController {
+	private logger = new Logger(SoundIdentificationController.name);
+	constructor(
+		private config: ConfigService,
+	) {}
+
+	frontendApiUsers = ["KE.389", "KE.841", "KE.542"];
+	soundIdentificationProxy = createProxyMiddleware({
+		target: this.config.get<string>("SOUND_IDENTIFICATION_HOST"),
+		changeOrigin: true,
+		pathRewrite: {
+			"^/sound-identification": "/classify"
+		},
+		logger: {
+			info: this.logger.verbose,
+			warn: this.logger.warn,
+			error: this.logger.error
+		}
+	});
+
+	@Post("/")
+	proxy(
+		@ApiUser() apiUser: ApiUserEntity,
+		@PersonToken() __: Person,
+		@Req() req: Request,
+		@Res() res: Response,
+		@Next() next: NextFunction
+	) {
+		if (!(apiUser.systemID && this.frontendApiUsers.includes(apiUser.systemID))) {
+			throw new HttpException("System is not allowed access to this endpoint", 403);
+		}
+
+		void this.soundIdentificationProxy(req, res, next);
+	}
+}

--- a/src/sound-identification/sound-identification.controller.ts
+++ b/src/sound-identification/sound-identification.controller.ts
@@ -14,7 +14,7 @@ export class SoundIdentificationController {
 		private config: ConfigService,
 	) {}
 
-	frontendApiUsers = ["KE.389", "KE.841", "KE.542"];
+	frontendApiUsers = ["KE.389", "KE.841", "KE.542", "KE.601"];
 	soundIdentificationProxy = createProxyMiddleware({
 		target: this.config.get<string>("SOUND_IDENTIFICATION_HOST"),
 		changeOrigin: true,


### PR DESCRIPTION
Added new endpoint for proxying requests from laji-front to sound-identifications server, validating that access_tokens belong to laji-front.